### PR TITLE
fix kaodv_expl_get usage

### DIFF
--- a/lnx/kaodv-netlink.c
+++ b/lnx/kaodv-netlink.c
@@ -189,7 +189,7 @@ static int kaodv_netlink_receive_peer(unsigned char type, void *msg,
 
 		ret = kaodv_expl_get(m->dst, &e);
 
-		if (ret < 0) {
+		if (ret > 0) {
 			ret = kaodv_expl_update(m->dst, m->nhop, m->time,
 						m->flags, m->ifindex);
 		} else {


### PR DESCRIPTION
kaodv_expl_get returns 1 or 0. 1 is returned when an entry was found.

It is not quiet clear if this is indeed a bug. But otherwise the first branch is never executed.

Signed-off-by: Moritz Warning <moritzwarning@web.de>